### PR TITLE
chore(deps): major update @types/node to v17.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1043,9 +1043,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-      "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
+      "integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@jest/types": "27.0.6",
     "@tsconfig/node12": "1.0.9",
     "@types/jest": "27.0.2",
-    "@types/node": "12.20.15",
+    "@types/node": "17.0.5",
     "@typescript-eslint/eslint-plugin": "5.4.0",
     "eslint": "8.3.0",
     "eslint-config-standard-with-typescript": "21.0.1",


### PR DESCRIPTION
This PR updates these packages:

|package|type|current version|new version|
|---|---|---|---|
|[@types/node](https://www.npmjs.com/package/@types/node)|major|`12.20.15`|`17.0.5`|

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.16.2