### PR TITLE
chore(deps): minor update jest to v27.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,27 +4,36 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.16.7"
+      }
+    },
     "@babel/compat-data": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
-      "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
+      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
-      "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.7.tgz",
+      "integrity": "sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.5",
-        "@babel/helper-compilation-targets": "^7.14.5",
-        "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helpers": "^7.14.6",
-        "@babel/parser": "^7.14.6",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.16.7",
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helpers": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -33,43 +42,6 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.14.5"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "json5": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -94,12 +66,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
-      "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.7.tgz",
+      "integrity": "sha512-/ST3Sg8MLGY5HVYmrjOgL60ENux/HfO/CsUh7y4MalThufhE/Ff/6EibFDHi4jiDCaWfJKoqbE6oTh21c5hrRg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5",
+        "@babel/types": "^7.16.7",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -113,14 +85,14 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
-      "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
+      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.14.5",
-        "@babel/helper-validator-option": "^7.14.5",
-        "browserslist": "^4.16.6",
+        "@babel/compat-data": "^7.16.4",
+        "@babel/helper-validator-option": "^7.16.7",
+        "browserslist": "^4.17.5",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -132,143 +104,144 @@
         }
       }
     },
-    "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+    "@babel/helper-environment-visitor": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
-      }
-    },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
-      "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
-      "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
+      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.14.5",
-        "@babel/helper-simple-access": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
-          "dev": true
-        }
-      }
-    },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-simple-access": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+      "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
       "dev": true
     },
-    "@babel/helper-replace-supers": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-      "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.14.5",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
-      }
-    },
     "@babel/helper-simple-access": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
-      "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
+      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "dev": true
+    },
     "@babel/helper-validator-option": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
-      "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.7.tgz",
+      "integrity": "sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
+      "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "@babel/parser": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
-      "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.7.tgz",
+      "integrity": "sha512-sR4eaSrnM7BV7QPzGfEX5paG/6wrZM3I0HDzfIAK06ESvo9oy3xBuVBxE3MbQaKNhvg8g/ixjMWo2CGpzpHsDA==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -380,118 +353,43 @@
       }
     },
     "@babel/plugin-syntax-typescript": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz",
-      "integrity": "sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.7.tgz",
+      "integrity": "sha512-YhUIJHHGkqPgEcMYkPCKTyGUdoGKWtopIycQyjJH8OjvRgOYsXsaKehLVPScKJWAULPxMa4N1vCe6szREFlZ7A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.14.5"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
-      "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.7.tgz",
+      "integrity": "sha512-8KWJPIb8c2VvY8AJrydh6+fVRo2ODx1wYBU2398xJVq0JomuLBZmVQzLPBblJgHIGYG4znCpUZUZ0Pt2vdmVYQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.5",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.7",
-        "@babel/types": "^7.14.5",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.16.7",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.14.5"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "globals": {
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -501,21 +399,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-      "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.7.tgz",
+      "integrity": "sha512-E8HuV7FO9qLpx6OtoGfUQ2cjIYnbFwvZWYBS+87EwtdMvmUPJSwykpovFB+8insbpF0uJcpr8KMUi64XZntZcg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
-          "dev": true
-        }
       }
     },
     "@bcoe/v8-coverage": {
@@ -682,104 +572,239 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.0.6.tgz",
-      "integrity": "sha512-fMlIBocSHPZ3JxgWiDNW/KPj6s+YRd0hicb33IrmelCcjXo/pXPwvuiKFmZz+XuqI/1u7nbUK10zSsWL/1aegg==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.4.2.tgz",
+      "integrity": "sha512-xknHThRsPB/To1FUbi6pCe43y58qFC03zfb6R7fDb/FfC7k2R3i1l+izRBJf8DI46KhYGRaF14Eo9A3qbBoixg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-message-util": "^27.4.2",
+        "jest-util": "^27.4.2",
         "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        }
       }
     },
     "@jest/core": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.0.6.tgz",
-      "integrity": "sha512-SsYBm3yhqOn5ZLJCtccaBcvD/ccTLCeuDv8U41WJH/V1MW5eKUkeMHT9U+Pw/v1m1AIWlnIW/eM2XzQr0rEmow==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.4.5.tgz",
+      "integrity": "sha512-3tm/Pevmi8bDsgvo73nX8p/WPng6KWlCyScW10FPEoN1HU4pwI83tJ3TsFvi1FfzsjwUlMNEPowgb/rPau/LTQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/reporters": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.4.2",
+        "@jest/reporters": "^27.4.5",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.5",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.0.6",
-        "jest-config": "^27.0.6",
-        "jest-haste-map": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-resolve-dependencies": "^27.0.6",
-        "jest-runner": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
-        "jest-watcher": "^27.0.6",
+        "jest-changed-files": "^27.4.2",
+        "jest-config": "^27.4.5",
+        "jest-haste-map": "^27.4.5",
+        "jest-message-util": "^27.4.2",
+        "jest-regex-util": "^27.4.0",
+        "jest-resolve": "^27.4.5",
+        "jest-resolve-dependencies": "^27.4.5",
+        "jest-runner": "^27.4.5",
+        "jest-runtime": "^27.4.5",
+        "jest-snapshot": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
+        "jest-watcher": "^27.4.2",
         "micromatch": "^4.0.4",
-        "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        }
       }
     },
     "@jest/environment": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.0.6.tgz",
-      "integrity": "sha512-4XywtdhwZwCpPJ/qfAkqExRsERW+UaoSRStSHCCiQTUpoYdLukj+YJbQSFrZjhlUDRZeNiU9SFH0u7iNimdiIg==",
+      "version": "27.4.4",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.4.4.tgz",
+      "integrity": "sha512-q+niMx7cJgt/t/b6dzLOh4W8Ef/8VyKG7hxASK39jakijJzbFBGpptx3RXz13FFV7OishQ9lTbv+dQ5K3EhfDQ==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/fake-timers": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
-        "jest-mock": "^27.0.6"
+        "jest-mock": "^27.4.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/fake-timers": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.0.6.tgz",
-      "integrity": "sha512-sqd+xTWtZ94l3yWDKnRTdvTeZ+A/V7SSKrxsrOKSqdyddb9CeNRF8fbhAU0D7ZJBpTTW2nbp6MftmKJDZfW2LQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.4.2.tgz",
+      "integrity": "sha512-f/Xpzn5YQk5adtqBgvw1V6bF8Nx3hY0OIRRpCvWcfPl0EAjdqWPdhH3t/3XpiWZqtjIEHDyMKP9ajpva1l4Zmg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
-        "@sinonjs/fake-timers": "^7.0.2",
+        "@jest/types": "^27.4.2",
+        "@sinonjs/fake-timers": "^8.0.1",
         "@types/node": "*",
-        "jest-message-util": "^27.0.6",
-        "jest-mock": "^27.0.6",
-        "jest-util": "^27.0.6"
+        "jest-message-util": "^27.4.2",
+        "jest-mock": "^27.4.2",
+        "jest-util": "^27.4.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        }
       }
     },
     "@jest/globals": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.0.6.tgz",
-      "integrity": "sha512-DdTGCP606rh9bjkdQ7VvChV18iS7q0IMJVP1piwTWyWskol4iqcVwthZmoJEf7obE1nc34OpIyoVGPeqLC+ryw==",
+      "version": "27.4.4",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.4.4.tgz",
+      "integrity": "sha512-bqpqQhW30BOreXM8bA8t8JbOQzsq/WnPTnBl+It3UxAD9J8yxEAaBEylHx1dtBapAr/UBk8GidXbzmqnee8tYQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/types": "^27.0.6",
-        "expect": "^27.0.6"
+        "@jest/environment": "^27.4.4",
+        "@jest/types": "^27.4.2",
+        "expect": "^27.4.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/reporters": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.0.6.tgz",
-      "integrity": "sha512-TIkBt09Cb2gptji3yJXb3EE+eVltW6BjO7frO7NEfjI9vSIYoISi5R3aI3KpEDXlB1xwB+97NXIqz84qYeYsfA==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.4.5.tgz",
+      "integrity": "sha512-3orsG4vi8zXuBqEoy2LbnC1kuvkg1KQUgqNxmxpQgIOQEPeV0onvZu+qDQnEoX8qTQErtqn/xzcnbpeTuOLSiA==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.4.2",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.5",
+        "@jest/types": "^27.4.2",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -790,21 +815,56 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-worker": "^27.0.6",
+        "jest-haste-map": "^27.4.5",
+        "jest-resolve": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "jest-worker": "^27.4.5",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
         "terminal-link": "^2.0.0",
-        "v8-to-istanbul": "^8.0.0"
+        "v8-to-istanbul": "^8.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        }
       }
     },
     "@jest/source-map": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.0.6.tgz",
-      "integrity": "sha512-Fek4mi5KQrqmlY07T23JRi0e7Z9bXTOOD86V/uS0EIW4PClvPDqZOyFlLpNJheS6QI0FNX1CgmPjtJ4EA/2M+g==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.4.0.tgz",
+      "integrity": "sha512-Ntjx9jzP26Bvhbm93z/AKcPRj/9wrkI88/gK60glXDx1q+IeI0rf7Lw2c89Ch6ofonB0On/iRDreQuQ6te9pgQ==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0",
@@ -813,50 +873,100 @@
       }
     },
     "@jest/test-result": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.0.6.tgz",
-      "integrity": "sha512-ja/pBOMTufjX4JLEauLxE3LQBPaI2YjGFtXexRAjt1I/MbfNlMx0sytSX3tn5hSLzQsR3Qy2rd0hc1BWojtj9w==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.4.2.tgz",
+      "integrity": "sha512-kr+bCrra9jfTgxHXHa2UwoQjxvQk3Am6QbpAiJ5x/50LW8llOYrxILkqY0lZRW/hu8FXesnudbql263+EW9iNA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.0.6.tgz",
-      "integrity": "sha512-bISzNIApazYOlTHDum9PwW22NOyDa6VI31n6JucpjTVM0jD6JDgqEZ9+yn575nDdPF0+4csYDxNNW13NvFQGZA==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.4.5.tgz",
+      "integrity": "sha512-n5woIn/1v+FT+9hniymHPARA9upYUmfi5Pw9ewVwXCDlK4F5/Gkees9v8vdjGdAIJ2MPHLHodiajLpZZanWzEQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.0.6",
+        "@jest/test-result": "^27.4.2",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.6",
-        "jest-runtime": "^27.0.6"
+        "jest-haste-map": "^27.4.5",
+        "jest-runtime": "^27.4.5"
       }
     },
     "@jest/transform": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.0.6.tgz",
-      "integrity": "sha512-rj5Dw+mtIcntAUnMlW/Vju5mr73u8yg+irnHwzgtgoeI6cCPOvUwQ0D1uQtc/APmWgvRweEb1g05pkUpxH3iCA==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.4.5.tgz",
+      "integrity": "sha512-PuMet2UlZtlGzwc6L+aZmR3I7CEBpqadO03pU40l2RNY2fFJ191b9/ITB44LNOhVtsyykx0OZvj0PCyuLm7Eew==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.4.2",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.6",
-        "jest-regex-util": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-haste-map": "^27.4.5",
+        "jest-regex-util": "^27.4.0",
+        "jest-util": "^27.4.2",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
         "source-map": "^0.6.1",
         "write-file-atomic": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        }
       }
     },
     "@jest/types": {
@@ -908,9 +1018,9 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
+      "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
@@ -947,9 +1057,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.14",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
-      "integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+      "version": "7.1.18",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
+      "integrity": "sha512-S7unDjm/C7z2A2R9NzfKCK1I+BAALDtxEmsJBwlB3EzNfb929ykjL++1CK9LO++EIp2fQrC8O+BwjKvz6UeDyQ==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -960,18 +1070,18 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
-      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
+      "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__template": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
-      "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
+      "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -979,9 +1089,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.0.tgz",
-      "integrity": "sha512-IilJZ1hJBUZwMOVDNTdflOOLzJB/ZtljYVa7k3gEZN/jqIJIPkWHC6dvbX+DD2CwZDHB9wAKzZPzzqMIkW37/w==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
+      "integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -1049,15 +1159,15 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.0.tgz",
-      "integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
+      "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
       "dev": true
     },
     "@types/stack-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
-      "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
+      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
     "@types/yargs": {
@@ -1390,9 +1500,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
       "dev": true
     },
     "acorn-globals": {
@@ -1403,6 +1513,14 @@
       "requires": {
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        }
       }
     },
     "acorn-jsx": {
@@ -1554,38 +1672,74 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.6.tgz",
-      "integrity": "sha512-iTJyYLNc4wRofASmofpOc5NK9QunwMk+TLFgGXsTFS8uEqmd8wdI7sga0FPe2oVH3b5Agt/EAK1QjPEuKL8VfA==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.4.5.tgz",
+      "integrity": "sha512-3uuUTjXbgtODmSv/DXO9nZfD52IyC2OYTFaXGRzL0kpykzroaquCrD5+lZNafTvZlnNqZHt5pb0M08qVBZnsnA==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/transform": "^27.4.5",
+        "@jest/types": "^27.4.2",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^27.0.6",
+        "babel-preset-jest": "^27.4.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "babel-plugin-istanbul": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
-      "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@istanbuljs/load-nyc-config": "^1.0.0",
         "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-instrument": "^5.0.4",
         "test-exclude": "^6.0.0"
+      },
+      "dependencies": {
+        "istanbul-lib-instrument": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
+          "integrity": "sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.3",
+            "@babel/parser": "^7.14.7",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.2.0",
+            "semver": "^6.3.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.6.tgz",
-      "integrity": "sha512-CewFeM9Vv2gM7Yr9n5eyyLVPRSiBnk6lKZRjgwYnGKSl9M14TMn2vkN02wTF04OGuSDLEzlWiMzvjXuW9mB6Gw==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.4.0.tgz",
+      "integrity": "sha512-Jcu7qS4OX5kTWBc45Hz7BMmgXuJqRnhatqpUhnzGC3OBYpOmf2tv6jFNwZpwM7wU7MUuv2r9IPS/ZlYOuburVw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -1615,12 +1769,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz",
-      "integrity": "sha512-WObA0/Biw2LrVVwZkF/2GqbOdzhKD6Fkdwhoy9ASIrOWr/zodcSpQh72JOkEn6NWyjmnPDjNSqaGN4KnpKzhXw==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.4.0.tgz",
+      "integrity": "sha512-NK4jGYpnBvNxcGo7/ZpZJr51jCGT+3bwwpVIDY2oNfTxJJldRtB4VAcYdgp1loDE50ODuTu+yBjpMAswv5tlpg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^27.0.6",
+        "babel-plugin-jest-hoist": "^27.4.0",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
@@ -1656,16 +1810,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
+      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001219",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.723",
+        "caniuse-lite": "^1.0.30001286",
+        "electron-to-chromium": "^1.4.17",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.71"
+        "node-releases": "^2.0.1",
+        "picocolors": "^1.0.0"
       }
     },
     "bs-logger": {
@@ -1687,9 +1841,9 @@
       }
     },
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
     "call-bind": {
@@ -1715,9 +1869,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001240",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001240.tgz",
-      "integrity": "sha512-nb8mDzfMdxBDN7ZKx8chWafAdBp5DAAlpWvNyUGe5tcDWd838zpzDN3Rah9cjCqhfOKkrvx40G2SDtP0qiWX/w==",
+      "version": "1.0.30001295",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001295.tgz",
+      "integrity": "sha512-lSP16vcyC0FEy0R4ECc9duSPoKoZy+YkpGkue9G4D81OfPnliopaZrU10+qtPdT8PbGXad/PNx43TIQrOmJZSQ==",
       "dev": true
     },
     "chalk": {
@@ -1784,9 +1938,9 @@
       "dev": true
     },
     "cjs-module-lexer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz",
-      "integrity": "sha512-jVamGdJPDeuQilKhvVn1h3knuMOZzr8QDnpk+M9aMlCaMkTDd6fBWPhiDqFvFZ07pL0liqabAiuy8SY4jGHeaw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
+      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
     "clean-stack": {
@@ -1890,12 +2044,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "colorette": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
     "combined-stream": {
@@ -2081,9 +2229,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.759",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.759.tgz",
-      "integrity": "sha512-nM76xH0t2FBH5iMEZDVc3S/qbdKjGH7TThezxC8k1Q7w7WHvIAyJh8lAe2UamGfdRqBTjHfPDn82LJ0ksCiB9g==",
+      "version": "1.4.31",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.31.tgz",
+      "integrity": "sha512-t3XVQtk+Frkv6aTD4RRk0OqosU+VLe1dQFW83MDer78ZD6a52frgXuYOIsLYTQiH2Lm+JB2OKYcn7zrX+YGAiQ==",
       "dev": true
     },
     "emittery": {
@@ -2172,9 +2320,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         },
         "levn": {
@@ -2665,9 +2813,9 @@
       "dev": true
     },
     "execa": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.0.tgz",
-      "integrity": "sha512-CkdUB7s2y6S+d4y+OM/+ZtQcJCiKUCth4cNImGMqrt2zEVtW2rfHGspQBE1GDo6LjeNIQmTPKXqTCKjqFKyu3A==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.3",
@@ -2679,14 +2827,6 @@
         "onetime": "^5.1.2",
         "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
-      },
-      "dependencies": {
-        "human-signals": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-          "dev": true
-        }
       }
     },
     "exit": {
@@ -2696,29 +2836,36 @@
       "dev": true
     },
     "expect": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.6.tgz",
-      "integrity": "sha512-psNLt8j2kwg42jGBDSfAlU49CEZxejN1f1PlANWDZqIhBOVU/c2Pm888FcjWJzFewhIsNWfZJeLjUjtKGiPuSw==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.4.2.tgz",
+      "integrity": "sha512-BjAXIDC6ZOW+WBFNg96J22D27Nq5ohn+oGcuP2rtOtcjuxNoV9McpQ60PcQWhdFOSBIQdR72e+4HdnbZTFSTyg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.4.2",
         "ansi-styles": "^5.0.0",
-        "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-regex-util": "^27.0.6"
+        "jest-get-type": "^27.4.0",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-regex-util": "^27.4.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "jest-get-type": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
-          "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
           "dev": true
         }
       }
@@ -3059,9 +3206,9 @@
       }
     },
     "import-local": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-      "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
+      "integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
       "dev": true,
       "requires": {
         "pkg-dir": "^4.2.0",
@@ -3335,9 +3482,9 @@
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "dev": true
     },
     "istanbul-lib-instrument": {
@@ -3389,9 +3536,9 @@
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
-      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -3400,9 +3547,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.3.tgz",
+      "integrity": "sha512-x9LtDVtfm/t1GFiLl3NffC7hz+I1ragvgX1P/Lg1NlIagifZDKUkuuaAxH/qpwj2IuEfD8G2Bs/UKp+sZ/pKkg==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -3410,148 +3557,221 @@
       }
     },
     "jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.0.6.tgz",
-      "integrity": "sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.4.5.tgz",
+      "integrity": "sha512-uT5MiVN3Jppt314kidCk47MYIRilJjA/l2mxwiuzzxGUeJIvA8/pDaJOAX5KWvjAo7SCydcW0/4WEtgbLMiJkg==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.0.6",
+        "@jest/core": "^27.4.5",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.0.6"
+        "jest-cli": "^27.4.5"
       },
       "dependencies": {
-        "jest-cli": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.0.6.tgz",
-          "integrity": "sha512-qUUVlGb9fdKir3RDE+B10ULI+LQrz+MCflEH2UJyoUjoHHCbxDrMxSzjQAPUMsic4SncI62ofYCcAvW6+6rhhg==",
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
           "dev": true,
           "requires": {
-            "@jest/core": "^27.0.6",
-            "@jest/test-result": "^27.0.6",
-            "@jest/types": "^27.0.6",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-cli": {
+          "version": "27.4.5",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.4.5.tgz",
+          "integrity": "sha512-hrky3DSgE0u7sQxaCL7bdebEPHx5QzYmrGuUjaPLmPE8jx5adtvGuOlRspvMoVLTTDOHRnZDoRLYJuA+VCI7Hg==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^27.4.5",
+            "@jest/test-result": "^27.4.2",
+            "@jest/types": "^27.4.2",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
-            "jest-config": "^27.0.6",
-            "jest-util": "^27.0.6",
-            "jest-validate": "^27.0.6",
+            "jest-config": "^27.4.5",
+            "jest-util": "^27.4.2",
+            "jest-validate": "^27.4.2",
             "prompts": "^2.0.1",
-            "yargs": "^16.0.3"
+            "yargs": "^16.2.0"
           }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
         }
       }
     },
     "jest-changed-files": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.0.6.tgz",
-      "integrity": "sha512-BuL/ZDauaq5dumYh5y20sn4IISnf1P9A0TDswTxUi84ORGtVa86ApuBHqICL0vepqAnZiY6a7xeSPWv2/yy4eA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.4.2.tgz",
+      "integrity": "sha512-/9x8MjekuzUQoPjDHbBiXbNEBauhrPU2ct7m8TfCg69ywt1y/N+yYwGh3gCpnqUS3klYWDU/lSNgv+JhoD2k1A==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.4.2",
         "execa": "^5.0.0",
         "throat": "^6.0.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-circus": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.0.6.tgz",
-      "integrity": "sha512-OJlsz6BBeX9qR+7O9lXefWoc2m9ZqcZ5Ohlzz0pTEAG4xMiZUJoacY8f4YDHxgk0oKYxj277AfOk9w6hZYvi1Q==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.4.5.tgz",
+      "integrity": "sha512-eTNWa9wsvBwPykhMMShheafbwyakcdHZaEYh5iRrQ0PFJxkDP/e3U/FvzGuKWu2WpwUA3C3hPlfpuzvOdTVqnw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/environment": "^27.4.4",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.0.6",
+        "expect": "^27.4.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "pretty-format": "^27.0.6",
+        "jest-each": "^27.4.2",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-runtime": "^27.4.5",
+        "jest-snapshot": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "pretty-format": "^27.4.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-          "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^27.0.6",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
           }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
         }
       }
     },
     "jest-config": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.0.6.tgz",
-      "integrity": "sha512-JZRR3I1Plr2YxPBhgqRspDE2S5zprbga3swYNrvY3HfQGu7p/GjyLOqwrYad97tX3U3mzT53TPHVmozacfP/3w==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.4.5.tgz",
+      "integrity": "sha512-t+STVJtPt+fpqQ8GBw850NtSQbnDOw/UzdPfzDaHQ48/AylQlW7LHj3dH+ndxhC1UxJ0Q3qkq7IH+nM1skwTwA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.0.6",
-        "@jest/types": "^27.0.6",
-        "babel-jest": "^27.0.6",
+        "@jest/test-sequencer": "^27.4.5",
+        "@jest/types": "^27.4.2",
+        "babel-jest": "^27.4.5",
         "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
-        "is-ci": "^3.0.0",
-        "jest-circus": "^27.0.6",
-        "jest-environment-jsdom": "^27.0.6",
-        "jest-environment-node": "^27.0.6",
-        "jest-get-type": "^27.0.6",
-        "jest-jasmine2": "^27.0.6",
-        "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-runner": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
+        "jest-circus": "^27.4.5",
+        "jest-environment-jsdom": "^27.4.4",
+        "jest-environment-node": "^27.4.4",
+        "jest-get-type": "^27.4.0",
+        "jest-jasmine2": "^27.4.5",
+        "jest-regex-util": "^27.4.0",
+        "jest-resolve": "^27.4.5",
+        "jest-runner": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.4.2",
+        "slash": "^3.0.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "jest-get-type": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
-          "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-          "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^27.0.6",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
           }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
         }
       }
     },
@@ -3568,80 +3788,159 @@
       }
     },
     "jest-docblock": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.0.6.tgz",
-      "integrity": "sha512-Fid6dPcjwepTFraz0YxIMCi7dejjJ/KL9FBjPYhBp4Sv1Y9PdhImlKZqYU555BlN4TQKaTc+F2Av1z+anVyGkA==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.4.0.tgz",
+      "integrity": "sha512-7TBazUdCKGV7svZ+gh7C8esAnweJoG+SvcF6Cjqj4l17zA2q1cMwx2JObSioubk317H+cjcHgP+7fTs60paulg==",
       "dev": true,
       "requires": {
         "detect-newline": "^3.0.0"
       }
     },
     "jest-each": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.0.6.tgz",
-      "integrity": "sha512-m6yKcV3bkSWrUIjxkE9OC0mhBZZdhovIW5ergBYirqnkLXkyEn3oUUF/QZgyecA1cF1QFyTE8bRRl8Tfg1pfLA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.4.2.tgz",
+      "integrity": "sha512-53V2MNyW28CTruB3lXaHNk6PkiIFuzdOC9gR3C6j8YE/ACfrPnz+slB0s17AgU1TtxNzLuHyvNlLJ+8QYw9nBg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.4.2",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "pretty-format": "^27.0.6"
+        "jest-get-type": "^27.4.0",
+        "jest-util": "^27.4.2",
+        "pretty-format": "^27.4.2"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "jest-get-type": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
-          "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-          "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^27.0.6",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
           }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
         }
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.0.6.tgz",
-      "integrity": "sha512-FvetXg7lnXL9+78H+xUAsra3IeZRTiegA3An01cWeXBspKXUhAwMM9ycIJ4yBaR0L7HkoMPaZsozCLHh4T8fuw==",
+      "version": "27.4.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.4.4.tgz",
+      "integrity": "sha512-cYR3ndNfHBqQgFvS1RL7dNqSvD//K56j/q1s2ygNHcfTCAp12zfIromO1w3COmXrxS8hWAh7+CmZmGCIoqGcGA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/environment": "^27.4.4",
+        "@jest/fake-timers": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
-        "jest-mock": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-mock": "^27.4.2",
+        "jest-util": "^27.4.2",
         "jsdom": "^16.6.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        }
       }
     },
     "jest-environment-node": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.0.6.tgz",
-      "integrity": "sha512-+Vi6yLrPg/qC81jfXx3IBlVnDTI6kmRr08iVa2hFCWmJt4zha0XW7ucQltCAPhSR0FEKEoJ3i+W4E6T0s9is0w==",
+      "version": "27.4.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.4.4.tgz",
+      "integrity": "sha512-D+v3lbJ2GjQTQR23TK0kY3vFVmSeea05giInI41HHOaJnAwOnmUHTZgUaZL+VxUB43pIzoa7PMwWtCVlIUoVoA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.0.6",
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/environment": "^27.4.4",
+        "@jest/fake-timers": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
-        "jest-mock": "^27.0.6",
-        "jest-util": "^27.0.6"
+        "jest-mock": "^27.4.2",
+        "jest-util": "^27.4.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        }
       }
     },
     "jest-get-type": {
@@ -3651,250 +3950,199 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.0.6.tgz",
-      "integrity": "sha512-4ldjPXX9h8doB2JlRzg9oAZ2p6/GpQUNAeiYXqcpmrKbP0Qev0wdZlxSMOmz8mPOEnt4h6qIzXFLDi8RScX/1w==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.4.5.tgz",
+      "integrity": "sha512-oJm1b5qhhPs78K24EDGifWS0dELYxnoBiDhatT/FThgB9yxqUm5F6li3Pv+Q+apMBmmPNzOBnZ7ZxWMB1Leq1Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.4.2",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
-        "jest-regex-util": "^27.0.6",
-        "jest-serializer": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-worker": "^27.0.6",
+        "jest-regex-util": "^27.4.0",
+        "jest-serializer": "^27.4.0",
+        "jest-util": "^27.4.2",
+        "jest-worker": "^27.4.5",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        }
       }
     },
     "jest-jasmine2": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.0.6.tgz",
-      "integrity": "sha512-cjpH2sBy+t6dvCeKBsHpW41mjHzXgsavaFMp+VWRf0eR4EW8xASk1acqmljFtK2DgyIECMv2yCdY41r2l1+4iA==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.4.5.tgz",
+      "integrity": "sha512-oUnvwhJDj2LhOiUB1kdnJjkx8C5PwgUZQb9urF77mELH9DGR4e2GqpWQKBOYXWs5+uTN9BGDqRz3Aeg5Wts7aw==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.0.6",
-        "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/environment": "^27.4.4",
+        "@jest/source-map": "^27.4.0",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.0.6",
+        "expect": "^27.4.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "pretty-format": "^27.0.6",
+        "jest-each": "^27.4.2",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-runtime": "^27.4.5",
+        "jest-snapshot": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "pretty-format": "^27.4.2",
         "throat": "^6.0.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-          "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^27.0.6",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
           }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
         }
       }
     },
     "jest-leak-detector": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.0.6.tgz",
-      "integrity": "sha512-2/d6n2wlH5zEcdctX4zdbgX8oM61tb67PQt4Xh8JFAIy6LRKUnX528HulkaG6nD5qDl5vRV1NXejCe1XRCH5gQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.4.2.tgz",
+      "integrity": "sha512-ml0KvFYZllzPBJWDei3mDzUhyp/M4ubKebX++fPaudpe8OsxUE+m+P6ciVLboQsrzOCWDjE20/eXew9QMx/VGw==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.0.6"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "jest-get-type": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
-          "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-          "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.0.6",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          }
-        }
+        "jest-get-type": "^27.4.0",
+        "pretty-format": "^27.4.2"
       }
     },
     "jest-matcher-utils": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.6.tgz",
-      "integrity": "sha512-OFgF2VCQx9vdPSYTHWJ9MzFCehs20TsyFi6bIHbk5V1u52zJOnvF0Y/65z3GLZHKRuTgVPY4Z6LVePNahaQ+tA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.4.2.tgz",
+      "integrity": "sha512-jyP28er3RRtMv+fmYC/PKG8wvAmfGcSNproVTW2Y0P/OY7/hWUOmsPfxN1jOhM+0u2xU984u2yEagGivz9OBGQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.0.6",
-        "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.0.6"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "diff-sequences": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
-          "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
-          "dev": true
-        },
-        "jest-diff": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
-          "integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^27.0.6",
-            "jest-get-type": "^27.0.6",
-            "pretty-format": "^27.0.6"
-          }
-        },
-        "jest-get-type": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
-          "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-          "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.0.6",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          }
-        }
+        "jest-diff": "^27.4.2",
+        "jest-get-type": "^27.4.0",
+        "pretty-format": "^27.4.2"
       }
     },
     "jest-message-util": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.6.tgz",
-      "integrity": "sha512-rBxIs2XK7rGy+zGxgi+UJKP6WqQ+KrBbD1YMj517HYN3v2BG66t3Xan3FWqYHKZwjdB700KiAJ+iES9a0M+ixw==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.4.2.tgz",
+      "integrity": "sha512-OMRqRNd9E0DkBLZpFtZkAGYOXl6ZpoMtQJWTAREJKDOFa0M6ptB7L67tp+cszMBkvSgKOhNtQp2Vbcz3ZZKo/w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.4.2",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.0.6",
+        "pretty-format": "^27.4.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
-          }
-        },
-        "pretty-format": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-          "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.0.6",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
           }
         }
       }
     },
     "jest-mock": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.0.6.tgz",
-      "integrity": "sha512-lzBETUoK8cSxts2NYXSBWT+EJNzmUVtVVwS1sU9GwE1DLCfGsngg+ZVSIe0yd0ZSm+y791esiuo+WSwpXJQ5Bw==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.4.2.tgz",
+      "integrity": "sha512-PDDPuyhoukk20JrQKeofK12hqtSka7mWH0QQuxSNgrdiPsrnYYLS6wbzu/HDlxZRzji5ylLRULeuI/vmZZDrYA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.4.2",
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-pnp-resolver": {
@@ -3904,103 +4152,222 @@
       "dev": true
     },
     "jest-regex-util": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
-      "integrity": "sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.4.0.tgz",
+      "integrity": "sha512-WeCpMpNnqJYMQoOjm1nTtsgbR4XHAk1u00qDoNBQoykM280+/TmgA5Qh5giC1ecy6a5d4hbSsHzpBtu5yvlbEg==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.0.6.tgz",
-      "integrity": "sha512-yKmIgw2LgTh7uAJtzv8UFHGF7Dm7XfvOe/LQ3Txv101fLM8cx2h1QVwtSJ51Q/SCxpIiKfVn6G2jYYMDNHZteA==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.4.5.tgz",
+      "integrity": "sha512-xU3z1BuOz/hUhVUL+918KqUgK+skqOuUsAi7A+iwoUldK6/+PW+utK8l8cxIWT9AW7IAhGNXjSAh1UYmjULZZw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.4.2",
         "chalk": "^4.0.0",
-        "escalade": "^3.1.1",
         "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.4.5",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "resolve": "^1.20.0",
+        "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        }
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.6.tgz",
-      "integrity": "sha512-mg9x9DS3BPAREWKCAoyg3QucCr0n6S8HEEsqRCKSPjPcu9HzRILzhdzY3imsLoZWeosEbJZz6TKasveczzpJZA==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.5.tgz",
+      "integrity": "sha512-elEVvkvRK51y037NshtEkEnukMBWvlPzZHiL847OrIljJ8yIsujD2GXRPqDXC4rEVKbcdsy7W0FxoZb4WmEs7w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
-        "jest-regex-util": "^27.0.6",
-        "jest-snapshot": "^27.0.6"
+        "@jest/types": "^27.4.2",
+        "jest-regex-util": "^27.4.0",
+        "jest-snapshot": "^27.4.5"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-runner": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.0.6.tgz",
-      "integrity": "sha512-W3Bz5qAgaSChuivLn+nKOgjqNxM7O/9JOJoKDCqThPIg2sH/d4A/lzyiaFgnb9V1/w29Le11NpzTJSzga1vyYQ==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.4.5.tgz",
+      "integrity": "sha512-/irauncTfmY1WkTaRQGRWcyQLzK1g98GYG/8QvIPviHgO1Fqz1JYeEIsSfF+9mc/UTA6S+IIHFgKyvUrtiBIZg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/environment": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.4.2",
+        "@jest/environment": "^27.4.4",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.5",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-docblock": "^27.0.6",
-        "jest-environment-jsdom": "^27.0.6",
-        "jest-environment-node": "^27.0.6",
-        "jest-haste-map": "^27.0.6",
-        "jest-leak-detector": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-runtime": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-worker": "^27.0.6",
+        "jest-docblock": "^27.4.0",
+        "jest-environment-jsdom": "^27.4.4",
+        "jest-environment-node": "^27.4.4",
+        "jest-haste-map": "^27.4.5",
+        "jest-leak-detector": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-resolve": "^27.4.5",
+        "jest-runtime": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "jest-worker": "^27.4.5",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        }
       }
     },
     "jest-runtime": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.0.6.tgz",
-      "integrity": "sha512-BhvHLRVfKibYyqqEFkybsznKwhrsu7AWx2F3y9G9L95VSIN3/ZZ9vBpm/XCS2bS+BWz3sSeNGLzI3TVQ0uL85Q==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.4.5.tgz",
+      "integrity": "sha512-CIYqwuJQXHQtPd/idgrx4zgJ6iCb6uBjQq1RSAGQrw2S8XifDmoM1Ot8NRd80ooAm+ZNdHVwsktIMGlA1F1FAQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.0.6",
-        "@jest/environment": "^27.0.6",
-        "@jest/fake-timers": "^27.0.6",
-        "@jest/globals": "^27.0.6",
-        "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.0.6",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/console": "^27.4.2",
+        "@jest/environment": "^27.4.4",
+        "@jest/globals": "^27.4.4",
+        "@jest/source-map": "^27.4.0",
+        "@jest/test-result": "^27.4.2",
+        "@jest/transform": "^27.4.5",
+        "@jest/types": "^27.4.2",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
+        "execa": "^5.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-mock": "^27.0.6",
-        "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-snapshot": "^27.0.6",
-        "jest-util": "^27.0.6",
-        "jest-validate": "^27.0.6",
+        "jest-haste-map": "^27.4.5",
+        "jest-message-util": "^27.4.2",
+        "jest-mock": "^27.4.2",
+        "jest-regex-util": "^27.4.0",
+        "jest-resolve": "^27.4.5",
+        "jest-snapshot": "^27.4.5",
+        "jest-util": "^27.4.2",
+        "jest-validate": "^27.4.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
-        "yargs": "^16.0.3"
+        "yargs": "^16.2.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
         "strip-bom": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -4010,9 +4377,9 @@
       }
     },
     "jest-serializer": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.0.6.tgz",
-      "integrity": "sha512-PtGdVK9EGC7dsaziskfqaAPib6wTViY3G8E5wz9tLVPhHyiDNTZn/xjZ4khAw+09QkoOVpn7vF5nPSN6dtBexA==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.4.0.tgz",
+      "integrity": "sha512-RDhpcn5f1JYTX2pvJAGDcnsNTnsV9bjYPU8xcV+xPwOXnUPOQwf4ZEuiU6G9H1UztH+OapMgu/ckEVwO87PwnQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -4020,9 +4387,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.0.6.tgz",
-      "integrity": "sha512-NTHaz8He+ATUagUgE7C/UtFcRoHqR2Gc+KDfhQIyx+VFgwbeEMjeP+ILpUTLosZn/ZtbNdCF5LkVnN/l+V751A==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.4.5.tgz",
+      "integrity": "sha512-eCi/iM1YJFrJWiT9de4+RpWWWBqsHiYxFG9V9o/n0WXs6GpW4lUt4FAHAgFPTLPqCUVzrMQmSmTZSgQzwqR7IQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
@@ -4031,67 +4398,58 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/transform": "^27.4.5",
+        "@jest/types": "^27.4.2",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.0.6",
+        "expect": "^27.4.2",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.0.6",
-        "jest-get-type": "^27.0.6",
-        "jest-haste-map": "^27.0.6",
-        "jest-matcher-utils": "^27.0.6",
-        "jest-message-util": "^27.0.6",
-        "jest-resolve": "^27.0.6",
-        "jest-util": "^27.0.6",
+        "jest-diff": "^27.4.2",
+        "jest-get-type": "^27.4.0",
+        "jest-haste-map": "^27.4.5",
+        "jest-matcher-utils": "^27.4.2",
+        "jest-message-util": "^27.4.2",
+        "jest-resolve": "^27.4.5",
+        "jest-util": "^27.4.2",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.0.6",
+        "pretty-format": "^27.4.2",
         "semver": "^7.3.2"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "diff-sequences": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
-          "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
-          "dev": true
-        },
-        "jest-diff": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
-          "integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
           "dev": true,
           "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
             "chalk": "^4.0.0",
-            "diff-sequences": "^27.0.6",
-            "jest-get-type": "^27.0.6",
-            "pretty-format": "^27.0.6"
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
           }
         },
-        "jest-get-type": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
-          "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
           "dev": true
-        },
-        "pretty-format": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-          "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.0.6",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          }
         }
       }
     },
@@ -4118,70 +4476,94 @@
       }
     },
     "jest-validate": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.0.6.tgz",
-      "integrity": "sha512-yhZZOaMH3Zg6DC83n60pLmdU1DQE46DW+KLozPiPbSbPhlXXaiUTDlhHQhHFpaqIFRrInko1FHXjTRpjWRuWfA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.4.2.tgz",
+      "integrity": "sha512-hWYsSUej+Fs8ZhOm5vhWzwSLmVaPAxRy+Mr+z5MzeaHm9AxUpXdoVMEW4R86y5gOobVfBsMFLk4Rb+QkiEpx1A==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.0.6",
+        "@jest/types": "^27.4.2",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.0.6",
+        "jest-get-type": "^27.4.0",
         "leven": "^3.1.0",
-        "pretty-format": "^27.0.6"
+        "pretty-format": "^27.4.2"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
-          "dev": true
-        },
-        "jest-get-type": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
-          "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-          "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^27.0.6",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
           }
+        },
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
         }
       }
     },
     "jest-watcher": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.0.6.tgz",
-      "integrity": "sha512-/jIoKBhAP00/iMGnTwUBLgvxkn7vsOweDrOTSPzc7X9uOyUtJIDthQBTI1EXz90bdkrxorUZVhJwiB69gcHtYQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.4.2.tgz",
+      "integrity": "sha512-NJvMVyyBeXfDezhWzUOCOYZrUmkSCiatpjpm+nFUid74OZEHk6aMLrZAukIiFDwdbqp6mTM6Ui1w4oc+8EobQg==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.0.6",
-        "@jest/types": "^27.0.6",
+        "@jest/test-result": "^27.4.2",
+        "@jest/types": "^27.4.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.0.6",
+        "jest-util": "^27.4.2",
         "string-length": "^4.0.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
+          "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.4",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        }
       }
     },
     "jest-worker": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
-      "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+      "version": "27.4.5",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.5.tgz",
+      "integrity": "sha512-f2s8kEdy15cv9r7q4KkzGXvlY0JTcmCbMHZBfSQDwW77REr45IDWwd0lksDFeVHH2jJ5pqb90T77XscrjeGzzg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -4213,9 +4595,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -4223,9 +4605,9 @@
       }
     },
     "jsdom": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
-      "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
       "dev": true,
       "requires": {
         "abab": "^2.0.5",
@@ -4253,16 +4635,8 @@
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.5.0",
-        "ws": "^7.4.5",
+        "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-          "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
-          "dev": true
-        }
       }
     },
     "jsesc": {
@@ -4577,12 +4951,12 @@
       "dev": true
     },
     "makeerror": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
-      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.x"
+        "tmpl": "1.0.5"
       }
     },
     "merge-stream": {
@@ -4616,18 +4990,18 @@
       }
     },
     "mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "dev": true,
       "requires": {
-        "mime-db": "1.48.0"
+        "mime-db": "1.51.0"
       }
     },
     "mimic-fn": {
@@ -4669,16 +5043,10 @@
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
-    "node-modules-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
-      "dev": true
-    },
     "node-releases": {
-      "version": "1.1.73",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
       "dev": true
     },
     "normalize-path": {
@@ -4769,12 +5137,6 @@
         "word-wrap": "^1.2.3"
       }
     },
-    "p-each-series": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
-      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
-      "dev": true
-    },
     "p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -4853,6 +5215,12 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -4860,13 +5228,10 @@
       "dev": true
     },
     "pirates": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
-      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
-      "dev": true,
-      "requires": {
-        "node-modules-regexp": "^1.0.0"
-      }
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
+      "integrity": "sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==",
+      "dev": true
     },
     "pkg-dir": {
       "version": "2.0.0",
@@ -4929,9 +5294,9 @@
       "dev": true
     },
     "prompts": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
-      "integrity": "sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
       "dev": true,
       "requires": {
         "kleur": "^3.0.3",
@@ -5005,6 +5370,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "resolve.exports": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
+      "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
       "dev": true
     },
     "restore-cursor": {
@@ -5166,9 +5537,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -5182,9 +5553,9 @@
       "dev": true
     },
     "stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
@@ -5354,9 +5725,9 @@
       "dev": true
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
@@ -5552,9 +5923,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz",
-      "integrity": "sha512-LkmXi8UUNxnCC+JlH7/fsfsKr5AU110l+SYGJimWNkWhxbN5EyeOtm1MJ0hhvqMMOhGwBj1Fp70Yv9i+hX0QAg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
+      "integrity": "sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -5589,12 +5960,12 @@
       }
     },
     "walker": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.x"
+        "makeerror": "1.0.12"
       }
     },
     "webidl-conversions": {
@@ -5713,9 +6084,9 @@
       }
     },
     "ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
       "dev": true
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "5.2.0",
     "husky": "7.0.4",
-    "jest": "27.0.6",
+    "jest": "27.4.5",
     "lint-staged": "12.1.4",
     "rimraf": "3.0.2",
     "ts-jest": "27.1.2",


### PR DESCRIPTION
This PR updates these packages:

|package|type|current version|new version|
|---|---|---|---|
|[jest](https://www.npmjs.com/package/jest)|minor|`27.0.6`|`27.4.5`|

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.19.2